### PR TITLE
feat: Add bootstrap pill styling to card action

### DIFF
--- a/generator/js/cards.js
+++ b/generator/js/cards.js
@@ -155,7 +155,7 @@ function card_element_pill(params, card_data, options) {
     var text = params[1];
 
     var result = "";
-    result += '<span class="card-pill ' + card_font_size_class + '" style="background-color:' + color + '">';
+    result += '<span class="card-pill pill bg-primary text-white ' + card_font_size_class + '" style="background-color:' + color + '">';
     result += text;
     result += '</span>';
     return result;


### PR DESCRIPTION
- Adjusts the pill action to have more of a default bootstrap pill styling (use bootstrap classes if possible) with rounded corners and a bit of padding.
- Makes the text color contrast the background color